### PR TITLE
Fix new clippy warnings

### DIFF
--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -243,7 +243,7 @@ impl AsCborValue for Header {
                                         .push(CoseSignature::from_cbor_value(sig)?);
                                 }
                             }
-                            v => return cbor_type_error(&v, &"array or bstr value"),
+                            v => return cbor_type_error(v, &"array or bstr value"),
                         }
                     }
                     v => return cbor_type_error(&v, &"array value"),

--- a/src/header/tests.rs
+++ b/src/header/tests.rs
@@ -361,9 +361,11 @@ fn test_header_encode_int_out_of_range_fail() {
     let result = cbor::ser::to_vec(&header);
     expect_err(result, "stored in CBOR");
 
-    let mut header = Header::default();
-    // "What we do, is if we need that extra push over the cliff, you know what we do?"
-    header.alg = Some(Algorithm::PrivateUse(MOST_NEGATIVE_NINT - 1));
+    let header = Header {
+        // "What we do, is if we need that extra push over the cliff, you know what we do?"
+        alg: Some(Algorithm::PrivateUse(MOST_NEGATIVE_NINT - 1)),
+        ..Default::default()
+    };
     let result = cbor::ser::to_vec(&header);
     expect_err(result, "stored in CBOR");
 }

--- a/src/iana/tests.rs
+++ b/src/iana/tests.rs
@@ -27,12 +27,12 @@ fn test_algorithm_conversion() {
 
 #[test]
 fn test_header_param_private_range() {
-    assert_eq!(HeaderParameter::is_private(1), false);
-    assert_eq!(HeaderParameter::is_private(-70_000), true);
+    assert!(!HeaderParameter::is_private(1));
+    assert!(HeaderParameter::is_private(-70_000));
 }
 
 #[test]
 fn test_elliptic_curve_private_range() {
-    assert_eq!(EllipticCurve::is_private(1), false);
-    assert_eq!(EllipticCurve::is_private(-70_000), true);
+    assert!(!EllipticCurve::is_private(1));
+    assert!(EllipticCurve::is_private(-70_000));
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -30,7 +30,7 @@ where
     Err(serde::de::Error::invalid_type(
         match v {
             cbor::Value::Integer(i) => serde::de::Unexpected::Signed(*i as i64),
-            cbor::Value::Text(t) => serde::de::Unexpected::Str(&t),
+            cbor::Value::Text(t) => serde::de::Unexpected::Str(t),
             cbor::Value::Null => serde::de::Unexpected::Unit,
             cbor::Value::Bool(b) => serde::de::Unexpected::Bool(*b),
             cbor::Value::Float(f) => serde::de::Unexpected::Float(*f),


### PR DESCRIPTION
- re-arrange construction to avoid field reassignment
- re-arrange vector construction to use vec![]
- use assert! for booleans
- drop unneeded &