### PR TITLE
 Preserve original protected contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
     - Drop `derive` of `Eq` for data types (`ciborium` supports float values, which are inherently non-`Eq`)
     - Add `#[must_use]` attributes to builder methods.
     - Update MSRV to 1.56.0, as `ciborium` is `edition=2021`
+- Use new `ProtectedHeader` type for protected headers (breaking change).  This variant of `Header` preserves any
+  originally-parsed data, so that calculations (signatures, decryption, etc.) over the data can use the bit-for-bit wire
+  data instead of a reconstituted (and potentially different) version.
 
 ## 0.2.0 - 2021-12-09
 

--- a/examples/signature.rs
+++ b/examples/signature.rs
@@ -84,7 +84,7 @@ fn main() {
         .is_err());
 
     // Changing a protected header invalidates the signature.
-    sign1.protected.content_type = Some(coset::ContentType::Text("text/plain".to_owned()));
+    sign1.protected.header.content_type = Some(coset::ContentType::Text("text/plain".to_owned()));
     assert!(sign1
         .verify_signature(aad, |sig, data| verifier.verify(sig, data))
         .is_err());

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     cbor::value::Value,
     iana,
     util::{cbor_type_error, AsCborValue},
-    Algorithm, CoseError, Header,
+    Algorithm, CoseError, ProtectedHeader,
 };
 use alloc::{vec, vec::Vec};
 use core::convert::TryInto;
@@ -129,7 +129,7 @@ impl PartyInfoBuilder {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct SuppPubInfo {
     pub key_data_length: u64,
-    pub protected: Header,
+    pub protected: ProtectedHeader,
     pub other: Option<Vec<u8>>,
 }
 
@@ -160,7 +160,7 @@ impl AsCborValue for SuppPubInfo {
                     None
                 }
             },
-            protected: Header::from_cbor_bstr(a.remove(1))?,
+            protected: ProtectedHeader::from_cbor_bstr(a.remove(1))?,
             key_data_length: match a.remove(0) {
                 Value::Integer(u) => u
                     .try_into()
@@ -189,7 +189,7 @@ pub struct SuppPubInfoBuilder(SuppPubInfo);
 impl SuppPubInfoBuilder {
     builder! {SuppPubInfo}
     builder_set! {key_data_length: u64}
-    builder_set! {protected: Header}
+    builder_set_protected! {protected}
     builder_set_optional! {other: Vec<u8>}
 }
 

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -201,7 +201,8 @@ fn test_context_encode() {
         let got = key.clone().to_vec().unwrap();
         assert_eq!(*key_data, hex::encode(&got), "case {}", i);
 
-        let got = CoseKdfContext::from_slice(&got).unwrap();
+        let mut got = CoseKdfContext::from_slice(&got).unwrap();
+        got.supp_pub_info.protected.original_data = None;
         assert_eq!(*key, got);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,8 @@
 //!     .is_err());
 //!
 //! // Changing a protected header invalidates the signature.
-//! sign1.protected.content_type = Some(coset::ContentType::Text("text/plain".to_owned()));
+//! sign1.protected.original_data = None;
+//! sign1.protected.header.content_type = Some(coset::ContentType::Text("text/plain".to_owned()));
 //! assert!(sign1
 //!     .verify_signature(aad, |sig, data| verifier.verify(sig, data))
 //!     .is_err());

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -104,3 +104,18 @@ macro_rules! builder_set_optional {
         }
     };
 }
+
+/// Add a setter function that fills out a `ProtectedHeader` from `Header` contents.
+macro_rules! builder_set_protected {
+    ( $name:ident ) => {
+        /// Set the associated field.
+        #[must_use]
+        pub fn $name(mut self, hdr: $crate::Header) -> Self {
+            self.0.$name = $crate::ProtectedHeader {
+                original_data: None,
+                header: hdr,
+            };
+            self
+        }
+    };
+}


### PR DESCRIPTION
Once a protected header (inside a `bstr`) is parsed, information about
the ordering of fields is lost, which means that (e.g.) signature checks
might not be correct.

For protected headers created from serialized data, preserve the
original `bstr` for use in bit-for-bit checks.

Alter tests to clear the `original_data` fields before any `assert_eq!`
comparisons.