### PR TITLE
Create CborError::OutOfRangeIntegerValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Use new `ProtectedHeader` type for protected headers (breaking change).  This variant of `Header` preserves any
   originally-parsed data, so that calculations (signatures, decryption, etc.) over the data can use the bit-for-bit wire
   data instead of a reconstituted (and potentially different) version.
+- Use new `OutOfRangeIntegerValue` error when an integer value is too large for the representation
+  used in this crate (breaking change).
 
 ## 0.2.0 - 2021-12-09
 

--- a/src/common/tests.rs
+++ b/src/common/tests.rs
@@ -330,8 +330,8 @@ fn test_large_label_decode() {
 #[test]
 fn test_large_label_decode_fail() {
     let tests = vec![
-        (CBOR_NINT_OUT_OF_RANGE_HEX, "got u64, expected u63"),
-        (CBOR_INT_OUT_OF_RANGE_HEX, "expected u63"),
+        (CBOR_NINT_OUT_OF_RANGE_HEX, "out of range integer value"),
+        (CBOR_INT_OUT_OF_RANGE_HEX, "out of range integer value"),
     ];
     for (label_data, err_msg) in tests.iter() {
         let data = hex::decode(label_data).unwrap();
@@ -343,8 +343,8 @@ fn test_large_label_decode_fail() {
 #[test]
 fn test_large_registered_label_decode_fail() {
     let tests = vec![
-        (CBOR_NINT_OUT_OF_RANGE_HEX, "got u64, expected u63"),
-        (CBOR_INT_OUT_OF_RANGE_HEX, "expected u63"),
+        (CBOR_NINT_OUT_OF_RANGE_HEX, "out of range integer value"),
+        (CBOR_INT_OUT_OF_RANGE_HEX, "out of range integer value"),
     ];
     for (label_data, err_msg) in tests.iter() {
         let data = hex::decode(label_data).unwrap();
@@ -356,8 +356,8 @@ fn test_large_registered_label_decode_fail() {
 #[test]
 fn test_large_registered_label_with_private_decode_fail() {
     let tests = vec![
-        (CBOR_NINT_OUT_OF_RANGE_HEX, "got u64, expected u63"),
-        (CBOR_INT_OUT_OF_RANGE_HEX, "expected u63"),
+        (CBOR_NINT_OUT_OF_RANGE_HEX, "out of range integer value"),
+        (CBOR_INT_OUT_OF_RANGE_HEX, "out of range integer value"),
     ];
     for (label_data, err_msg) in tests.iter() {
         let data = hex::decode(label_data).unwrap();

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -73,10 +73,7 @@ impl AsCborValue for PartyInfo {
             nonce: match a.remove(1) {
                 Value::Null => None,
                 Value::Bytes(b) => Some(Nonce::Bytes(b)),
-                Value::Integer(u) => Some(Nonce::Integer(
-                    u.try_into()
-                        .map_err(|_| CoseError::UnexpectedType("u64", "u63"))?,
-                )),
+                Value::Integer(u) => Some(Nonce::Integer(u.try_into()?)),
                 v => return cbor_type_error(&v, "bstr / int / nil"),
             },
             identity: match a.remove(0) {
@@ -162,9 +159,7 @@ impl AsCborValue for SuppPubInfo {
             },
             protected: ProtectedHeader::from_cbor_bstr(a.remove(1))?,
             key_data_length: match a.remove(0) {
-                Value::Integer(u) => u
-                    .try_into()
-                    .map_err(|_e| CoseError::UnexpectedType("u64", "u63"))?,
+                Value::Integer(u) => u.try_into()?,
                 v => return cbor_type_error(&v, "uint"),
             },
         })

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -380,7 +380,7 @@ fn test_context_decode_fail() {
                 "82", // 2-tuple: [0, 0-bstr]
                 "0040",
             ),
-            "got u64, expected u63",
+            "out of range integer value",
         ),
     ];
     for (context_data, err_msg) in tests.iter() {


### PR DESCRIPTION
Handle all failed int conversions with a purpose-built error.