### PR TITLE
Refactor for brevity and clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     - Use new `DuplicateMapKey` error when a CBOR map contains duplicate keys (and is thus invalid).
     - Extend `DecodeFailed` error to include the underlying `ciborium::de::Error` value.
     - Use new `ExtraneousData` error when data remains after reading a CBOR value.
+- Add a crate-specific `Result` type whose `E` field defaults to `CoseError`.
 
 ## 0.2.0 - 2021-12-09
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     cbor::value::Value,
     iana,
     util::{cbor_type_error, AsCborValue, ValueTryAs},
-    Algorithm, CoseError, ProtectedHeader,
+    Algorithm, CoseError, ProtectedHeader, Result,
 };
 use alloc::{vec, vec::Vec};
 use core::convert::TryInto;
@@ -54,7 +54,7 @@ pub struct PartyInfo {
 impl crate::CborSerializable for PartyInfo {}
 
 impl AsCborValue for PartyInfo {
-    fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
+    fn from_cbor_value(value: Value) -> Result<Self> {
         let mut a = value.try_as_array()?;
         if a.len() != 3 {
             return Err(CoseError::UnexpectedType("array", "array with 3 items"));
@@ -81,7 +81,7 @@ impl AsCborValue for PartyInfo {
         })
     }
 
-    fn to_cbor_value(self) -> Result<Value, CoseError> {
+    fn to_cbor_value(self) -> Result<Value> {
         Ok(Value::Array(vec![
             match self.identity {
                 None => Value::Null,
@@ -130,7 +130,7 @@ pub struct SuppPubInfo {
 impl crate::CborSerializable for SuppPubInfo {}
 
 impl AsCborValue for SuppPubInfo {
-    fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
+    fn from_cbor_value(value: Value) -> Result<Self> {
         let mut a = value.try_as_array()?;
         if a.len() != 2 && a.len() != 3 {
             return Err(CoseError::UnexpectedType(
@@ -153,7 +153,7 @@ impl AsCborValue for SuppPubInfo {
         })
     }
 
-    fn to_cbor_value(self) -> Result<Value, CoseError> {
+    fn to_cbor_value(self) -> Result<Value> {
         let mut v = vec![
             Value::from(self.key_data_length),
             self.protected.cbor_bstr()?,
@@ -202,7 +202,7 @@ pub struct CoseKdfContext {
 impl crate::CborSerializable for CoseKdfContext {}
 
 impl AsCborValue for CoseKdfContext {
-    fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
+    fn from_cbor_value(value: Value) -> Result<Self> {
         let mut a = value.try_as_array()?;
         if a.len() < 4 {
             return Err(CoseError::UnexpectedType(
@@ -227,7 +227,7 @@ impl AsCborValue for CoseKdfContext {
         })
     }
 
-    fn to_cbor_value(self) -> Result<Value, CoseError> {
+    fn to_cbor_value(self) -> Result<Value> {
         let mut v = vec![
             self.algorithm_id.to_cbor_value()?,
             self.party_u_info.to_cbor_value()?,

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -19,7 +19,7 @@
 use crate::{
     cbor::value::Value,
     iana,
-    util::{cbor_type_error, AsCborValue},
+    util::{cbor_type_error, AsCborValue, ValueTryAs},
     Algorithm, CoseError, ProtectedHeader,
 };
 use alloc::{vec, vec::Vec};
@@ -55,10 +55,7 @@ impl crate::CborSerializable for PartyInfo {}
 
 impl AsCborValue for PartyInfo {
     fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
-        let mut a = match value {
-            Value::Array(a) => a,
-            v => return cbor_type_error(&v, "array"),
-        };
+        let mut a = value.try_as_array()?;
         if a.len() != 3 {
             return Err(CoseError::UnexpectedType("array", "array with 3 items"));
         }
@@ -134,10 +131,7 @@ impl crate::CborSerializable for SuppPubInfo {}
 
 impl AsCborValue for SuppPubInfo {
     fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
-        let mut a = match value {
-            Value::Array(a) => a,
-            v => return cbor_type_error(&v, "array"),
-        };
+        let mut a = value.try_as_array()?;
         if a.len() != 2 && a.len() != 3 {
             return Err(CoseError::UnexpectedType(
                 "array",
@@ -149,19 +143,13 @@ impl AsCborValue for SuppPubInfo {
         Ok(Self {
             other: {
                 if a.len() == 3 {
-                    match a.remove(2) {
-                        Value::Bytes(b) => Some(b),
-                        v => return cbor_type_error(&v, "bstr"),
-                    }
+                    Some(a.remove(2).try_as_bytes()?)
                 } else {
                     None
                 }
             },
             protected: ProtectedHeader::from_cbor_bstr(a.remove(1))?,
-            key_data_length: match a.remove(0) {
-                Value::Integer(u) => u.try_into()?,
-                v => return cbor_type_error(&v, "uint"),
-            },
+            key_data_length: a.remove(0).try_as_integer()?.try_into()?,
         })
     }
 
@@ -215,10 +203,7 @@ impl crate::CborSerializable for CoseKdfContext {}
 
 impl AsCborValue for CoseKdfContext {
     fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
-        let mut a = match value {
-            Value::Array(a) => a,
-            v => return cbor_type_error(&v, "array"),
-        };
+        let mut a = value.try_as_array()?;
         if a.len() < 4 {
             return Err(CoseError::UnexpectedType(
                 "array",
@@ -229,11 +214,7 @@ impl AsCborValue for CoseKdfContext {
         // Remove array elements in reverse order to avoid shifts.
         let mut supp_priv_info = Vec::with_capacity(a.len() - 4);
         for i in (4..a.len()).rev() {
-            let b = match a.remove(i) {
-                Value::Bytes(b) => b,
-                v => return cbor_type_error(&v, "bstr"),
-            };
-            supp_priv_info.push(b);
+            supp_priv_info.push(a.remove(i).try_as_bytes()?);
         }
         supp_priv_info.reverse();
 

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -336,7 +336,7 @@ fn test_context_decode_fail() {
                 "83", "f6f6f6", // 3-tuple: [nil, nil, nil]
                 "82", "4040", // 2-tuple: [0-bstr, 0-bstr]
             ),
-            "expected uint",
+            "expected int",
         ),
         (
             concat!(
@@ -346,7 +346,7 @@ fn test_context_decode_fail() {
                 "83", "f6f6f6", // 3-tuple: [nil, nil, nil]
                 "82", "0060", // 2-tuple: [0, 0-tstr]
             ),
-            "expected bstr encoded map",
+            "expected bstr",
         ),
         (
             concat!(

--- a/src/encrypt/mod.rs
+++ b/src/encrypt/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     cbor,
     cbor::value::Value,
     iana,
-    util::{cbor_type_error, AsCborValue},
+    util::{cbor_type_error, AsCborValue, ValueTryAs},
     CoseError, Header, ProtectedHeader,
 };
 use alloc::{borrow::ToOwned, vec, vec::Vec};
@@ -49,10 +49,7 @@ impl crate::CborSerializable for CoseRecipient {}
 
 impl AsCborValue for CoseRecipient {
     fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
-        let mut a = match value {
-            Value::Array(a) => a,
-            v => return cbor_type_error(&v, "array"),
-        };
+        let mut a = value.try_as_array()?;
         if a.len() != 3 && a.len() != 4 {
             return Err(CoseError::UnexpectedType(
                 "array",
@@ -63,13 +60,8 @@ impl AsCborValue for CoseRecipient {
         // Remove array elements in reverse order to avoid shifts.
         let mut recipients = Vec::new();
         if a.len() == 4 {
-            match a.remove(3) {
-                Value::Array(a) => {
-                    for val in a {
-                        recipients.push(CoseRecipient::from_cbor_value(val)?);
-                    }
-                }
-                v => return cbor_type_error(&v, "array"),
+            for val in a.remove(3).try_as_array()? {
+                recipients.push(CoseRecipient::from_cbor_value(val)?);
             }
         }
 
@@ -237,23 +229,15 @@ impl crate::TaggedCborSerializable for CoseEncrypt {
 
 impl AsCborValue for CoseEncrypt {
     fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
-        let mut a = match value {
-            Value::Array(a) => a,
-            v => return cbor_type_error(&v, "array"),
-        };
+        let mut a = value.try_as_array()?;
         if a.len() != 4 {
             return Err(CoseError::UnexpectedType("array", "array with 4 items"));
         }
 
         // Remove array elements in reverse order to avoid shifts.
         let mut recipients = Vec::new();
-        match a.remove(3) {
-            Value::Array(a) => {
-                for val in a {
-                    recipients.push(CoseRecipient::from_cbor_value(val)?);
-                }
-            }
-            v => return cbor_type_error(&v, "array"),
+        for val in a.remove(3).try_as_array()? {
+            recipients.push(CoseRecipient::from_cbor_value(val)?);
         }
         Ok(Self {
             recipients,
@@ -382,10 +366,7 @@ impl crate::TaggedCborSerializable for CoseEncrypt0 {
 
 impl AsCborValue for CoseEncrypt0 {
     fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
-        let mut a = match value {
-            Value::Array(a) => a,
-            v => return cbor_type_error(&v, "array"),
-        };
+        let mut a = value.try_as_array()?;
         if a.len() != 3 {
             return Err(CoseError::UnexpectedType("array", "array with 3 items"));
         }

--- a/src/encrypt/mod.rs
+++ b/src/encrypt/mod.rs
@@ -60,10 +60,7 @@ impl AsCborValue for CoseRecipient {
         // Remove array elements in reverse order to avoid shifts.
         let recipients = if a.len() == 4 {
             a.remove(3)
-                .try_as_array()?
-                .into_iter()
-                .map(CoseRecipient::from_cbor_value)
-                .collect::<Result<Vec<_>, _>>()?
+                .try_as_array_then_convert(CoseRecipient::from_cbor_value)?
         } else {
             Vec::new()
         };
@@ -236,10 +233,7 @@ impl AsCborValue for CoseEncrypt {
         // Remove array elements in reverse order to avoid shifts.
         let recipients = a
             .remove(3)
-            .try_as_array()?
-            .into_iter()
-            .map(CoseRecipient::from_cbor_value)
-            .collect::<Result<Vec<_>, _>>()?;
+            .try_as_array_then_convert(CoseRecipient::from_cbor_value)?;
         Ok(Self {
             recipients,
             ciphertext: match a.remove(2) {

--- a/src/encrypt/mod.rs
+++ b/src/encrypt/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     cbor,
     cbor::value::Value,
     iana,
-    util::{cbor_type_error, AsCborValue, ValueTryAs},
+    util::{cbor_type_error, to_cbor_array, AsCborValue, ValueTryAs},
     CoseError, Header, ProtectedHeader,
 };
 use alloc::{borrow::ToOwned, vec, vec::Vec};
@@ -90,12 +90,7 @@ impl AsCborValue for CoseRecipient {
             },
         ];
         if !self.recipients.is_empty() {
-            v.push(Value::Array(
-                self.recipients
-                    .into_iter()
-                    .map(|r| r.to_cbor_value())
-                    .collect::<Result<Vec<_>, _>>()?,
-            ));
+            v.push(to_cbor_array(self.recipients)?);
         }
         Ok(Value::Array(v))
     }
@@ -258,11 +253,6 @@ impl AsCborValue for CoseEncrypt {
     }
 
     fn to_cbor_value(self) -> Result<Value, CoseError> {
-        let arr = self
-            .recipients
-            .into_iter()
-            .map(|r| r.to_cbor_value())
-            .collect::<Result<Vec<_>, _>>()?;
         Ok(Value::Array(vec![
             self.protected.cbor_bstr()?,
             self.unprotected.to_cbor_value()?,
@@ -270,7 +260,7 @@ impl AsCborValue for CoseEncrypt {
                 None => Value::Null,
                 Some(b) => Value::Bytes(b),
             },
-            Value::Array(arr),
+            to_cbor_array(self.recipients)?,
         ]))
     }
 }

--- a/src/encrypt/mod.rs
+++ b/src/encrypt/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     cbor::value::Value,
     iana,
     util::{cbor_type_error, to_cbor_array, AsCborValue, ValueTryAs},
-    CoseError, Header, ProtectedHeader,
+    CoseError, Header, ProtectedHeader, Result,
 };
 use alloc::{borrow::ToOwned, vec, vec::Vec};
 
@@ -48,7 +48,7 @@ pub struct CoseRecipient {
 impl crate::CborSerializable for CoseRecipient {}
 
 impl AsCborValue for CoseRecipient {
-    fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
+    fn from_cbor_value(value: Value) -> Result<Self> {
         let mut a = value.try_as_array()?;
         if a.len() != 3 && a.len() != 4 {
             return Err(CoseError::UnexpectedType(
@@ -80,7 +80,7 @@ impl AsCborValue for CoseRecipient {
         })
     }
 
-    fn to_cbor_value(self) -> Result<Value, CoseError> {
+    fn to_cbor_value(self) -> Result<Value> {
         let mut v = vec![
             self.protected.cbor_bstr()?,
             self.unprotected.to_cbor_value()?,
@@ -227,7 +227,7 @@ impl crate::TaggedCborSerializable for CoseEncrypt {
 }
 
 impl AsCborValue for CoseEncrypt {
-    fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
+    fn from_cbor_value(value: Value) -> Result<Self> {
         let mut a = value.try_as_array()?;
         if a.len() != 4 {
             return Err(CoseError::UnexpectedType("array", "array with 4 items"));
@@ -252,7 +252,7 @@ impl AsCborValue for CoseEncrypt {
         })
     }
 
-    fn to_cbor_value(self) -> Result<Value, CoseError> {
+    fn to_cbor_value(self) -> Result<Value> {
         Ok(Value::Array(vec![
             self.protected.cbor_bstr()?,
             self.unprotected.to_cbor_value()?,
@@ -362,7 +362,7 @@ impl crate::TaggedCborSerializable for CoseEncrypt0 {
 }
 
 impl AsCborValue for CoseEncrypt0 {
-    fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
+    fn from_cbor_value(value: Value) -> Result<Self> {
         let mut a = value.try_as_array()?;
         if a.len() != 3 {
             return Err(CoseError::UnexpectedType("array", "array with 3 items"));
@@ -381,7 +381,7 @@ impl AsCborValue for CoseEncrypt0 {
         })
     }
 
-    fn to_cbor_value(self) -> Result<Value, CoseError> {
+    fn to_cbor_value(self) -> Result<Value> {
         Ok(Value::Array(vec![
             self.protected.cbor_bstr()?,
             self.unprotected.to_cbor_value()?,

--- a/src/encrypt/mod.rs
+++ b/src/encrypt/mod.rs
@@ -58,12 +58,15 @@ impl AsCborValue for CoseRecipient {
         }
 
         // Remove array elements in reverse order to avoid shifts.
-        let mut recipients = Vec::new();
-        if a.len() == 4 {
-            for val in a.remove(3).try_as_array()? {
-                recipients.push(CoseRecipient::from_cbor_value(val)?);
-            }
-        }
+        let recipients = if a.len() == 4 {
+            a.remove(3)
+                .try_as_array()?
+                .into_iter()
+                .map(|val| CoseRecipient::from_cbor_value(val))
+                .collect::<Result<Vec<_>, _>>()?
+        } else {
+            Vec::new()
+        };
 
         Ok(Self {
             recipients,
@@ -87,11 +90,12 @@ impl AsCborValue for CoseRecipient {
             },
         ];
         if !self.recipients.is_empty() {
-            let mut arr = Vec::new();
-            for r in self.recipients {
-                arr.push(r.to_cbor_value()?);
-            }
-            v.push(Value::Array(arr));
+            v.push(Value::Array(
+                self.recipients
+                    .into_iter()
+                    .map(|r| r.to_cbor_value())
+                    .collect::<Result<Vec<_>, _>>()?,
+            ));
         }
         Ok(Value::Array(v))
     }
@@ -235,10 +239,12 @@ impl AsCborValue for CoseEncrypt {
         }
 
         // Remove array elements in reverse order to avoid shifts.
-        let mut recipients = Vec::new();
-        for val in a.remove(3).try_as_array()? {
-            recipients.push(CoseRecipient::from_cbor_value(val)?);
-        }
+        let recipients = a
+            .remove(3)
+            .try_as_array()?
+            .into_iter()
+            .map(|val| CoseRecipient::from_cbor_value(val))
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(Self {
             recipients,
             ciphertext: match a.remove(2) {
@@ -252,10 +258,11 @@ impl AsCborValue for CoseEncrypt {
     }
 
     fn to_cbor_value(self) -> Result<Value, CoseError> {
-        let mut arr = Vec::new();
-        for r in self.recipients {
-            arr.push(r.to_cbor_value()?);
-        }
+        let arr = self
+            .recipients
+            .into_iter()
+            .map(|r| r.to_cbor_value())
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(Value::Array(vec![
             self.protected.cbor_bstr()?,
             self.unprotected.to_cbor_value()?,

--- a/src/encrypt/mod.rs
+++ b/src/encrypt/mod.rs
@@ -62,7 +62,7 @@ impl AsCborValue for CoseRecipient {
             a.remove(3)
                 .try_as_array()?
                 .into_iter()
-                .map(|val| CoseRecipient::from_cbor_value(val))
+                .map(CoseRecipient::from_cbor_value)
                 .collect::<Result<Vec<_>, _>>()?
         } else {
             Vec::new()
@@ -238,7 +238,7 @@ impl AsCborValue for CoseEncrypt {
             .remove(3)
             .try_as_array()?
             .into_iter()
-            .map(|val| CoseRecipient::from_cbor_value(val))
+            .map(CoseRecipient::from_cbor_value)
             .collect::<Result<Vec<_>, _>>()?;
         Ok(Self {
             recipients,

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     cbor::value::Value,
     iana,
     iana::EnumI64,
-    util::{cbor_type_error, AsCborValue, ValueTryAs},
+    util::{cbor_type_error, to_cbor_array, AsCborValue, ValueTryAs},
     Algorithm, CborSerializable, CoseError, CoseSignature, Label, RegisteredLabel,
 };
 use alloc::{collections::BTreeSet, string::String, vec, vec::Vec};
@@ -210,12 +210,7 @@ impl AsCborValue for Header {
             map.push((ALG.to_cbor_value()?, alg.to_cbor_value()?));
         }
         if !self.crit.is_empty() {
-            let arr = self
-                .crit
-                .into_iter()
-                .map(|c| c.to_cbor_value())
-                .collect::<Result<Vec<_>, _>>()?;
-            map.push((CRIT.to_cbor_value()?, Value::Array(arr)));
+            map.push((CRIT.to_cbor_value()?, to_cbor_array(self.crit)?));
         }
         if let Some(content_type) = self.content_type {
             map.push((CONTENT_TYPE.to_cbor_value()?, content_type.to_cbor_value()?));
@@ -237,12 +232,10 @@ impl AsCborValue for Header {
                     self.counter_signatures.remove(0).to_cbor_value()?,
                 ));
             } else {
-                let arr = self
-                    .counter_signatures
-                    .into_iter()
-                    .map(|cs| cs.to_cbor_value())
-                    .collect::<Result<Vec<_>, _>>()?;
-                map.push((COUNTER_SIG.to_cbor_value()?, Value::Array(arr)));
+                map.push((
+                    COUNTER_SIG.to_cbor_value()?,
+                    to_cbor_array(self.counter_signatures)?,
+                ));
             }
         }
         let mut seen = BTreeSet::new();

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -225,10 +225,11 @@ impl AsCborValue for Header {
             map.push((alg_value(), alg.to_cbor_value()?));
         }
         if !self.crit.is_empty() {
-            let mut arr = Vec::new();
-            for c in self.crit {
-                arr.push(c.to_cbor_value()?);
-            }
+            let arr = self
+                .crit
+                .into_iter()
+                .map(|c| c.to_cbor_value())
+                .collect::<Result<Vec<_>, _>>()?;
             map.push((crit_value(), Value::Array(arr)));
         }
         if let Some(content_type) = self.content_type {
@@ -251,10 +252,11 @@ impl AsCborValue for Header {
                     self.counter_signatures.remove(0).to_cbor_value()?,
                 ));
             } else {
-                let mut arr = Vec::new();
-                for cs in self.counter_signatures {
-                    arr.push(cs.to_cbor_value()?);
-                }
+                let arr = self
+                    .counter_signatures
+                    .into_iter()
+                    .map(|cs| cs.to_cbor_value())
+                    .collect::<Result<Vec<_>, _>>()?;
                 map.push((counter_sig_value(), Value::Array(arr)));
             }
         }

--- a/src/header/tests.rs
+++ b/src/header/tests.rs
@@ -324,7 +324,7 @@ fn test_header_decode_fail() {
                 "a1", // 1-map
                 "07", "01", // 7 (counter-sig) => invalid value type
             ),
-            "expected array value",
+            "expected array",
         ),
         (
             concat!(

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -49,11 +49,7 @@ impl crate::CborSerializable for CoseKeySet {}
 impl AsCborValue for CoseKeySet {
     fn from_cbor_value(value: Value) -> Result<Self> {
         Ok(Self(
-            value
-                .try_as_array()?
-                .into_iter()
-                .map(CoseKey::from_cbor_value)
-                .collect::<Result<Vec<_>, _>>()?,
+            value.try_as_array_then_convert(CoseKey::from_cbor_value)?,
         ))
     }
 

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     iana,
     iana::EnumI64,
     util::{to_cbor_array, AsCborValue, ValueTryAs},
-    Algorithm, CoseError, Label,
+    Algorithm, CoseError, Label, Result,
 };
 use alloc::{collections::BTreeSet, vec, vec::Vec};
 
@@ -47,7 +47,7 @@ pub struct CoseKeySet(pub Vec<CoseKey>);
 impl crate::CborSerializable for CoseKeySet {}
 
 impl AsCborValue for CoseKeySet {
-    fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
+    fn from_cbor_value(value: Value) -> Result<Self> {
         Ok(Self(
             value
                 .try_as_array()?
@@ -57,7 +57,7 @@ impl AsCborValue for CoseKeySet {
         ))
     }
 
-    fn to_cbor_value(self) -> Result<Value, CoseError> {
+    fn to_cbor_value(self) -> Result<Value> {
         to_cbor_array(self.0)
     }
 }
@@ -100,7 +100,7 @@ const KEY_OPS: Label = Label::Int(iana::KeyParameter::KeyOps as i64);
 const BASE_IV: Label = Label::Int(iana::KeyParameter::BaseIv as i64);
 
 impl AsCborValue for CoseKey {
-    fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
+    fn from_cbor_value(value: Value) -> Result<Self> {
         let m = value.try_as_map()?;
         let mut key = Self::default();
         let mut seen = BTreeSet::new();
@@ -154,7 +154,7 @@ impl AsCborValue for CoseKey {
         Ok(key)
     }
 
-    fn to_cbor_value(self) -> Result<Value, CoseError> {
+    fn to_cbor_value(self) -> Result<Value> {
         let mut map: Vec<(Value, Value)> = vec![(KTY.to_cbor_value()?, self.kty.to_cbor_value()?)];
         if !self.key_id.is_empty() {
             map.push((KID.to_cbor_value()?, Value::Bytes(self.key_id)));

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     cbor::value::Value,
     iana,
     iana::EnumI64,
-    util::{AsCborValue, ValueTryAs},
+    util::{to_cbor_array, AsCborValue, ValueTryAs},
     Algorithm, CoseError, Label,
 };
 use alloc::{collections::BTreeSet, vec, vec::Vec};
@@ -58,12 +58,7 @@ impl AsCborValue for CoseKeySet {
     }
 
     fn to_cbor_value(self) -> Result<Value, CoseError> {
-        Ok(Value::Array(
-            self.0
-                .into_iter()
-                .map(|k| k.to_cbor_value())
-                .collect::<Result<Vec<_>, _>>()?,
-        ))
+        to_cbor_array(self.0)
     }
 }
 
@@ -168,12 +163,7 @@ impl AsCborValue for CoseKey {
             map.push((ALG.to_cbor_value()?, alg.to_cbor_value()?));
         }
         if !self.key_ops.is_empty() {
-            let arr = self
-                .key_ops
-                .into_iter()
-                .map(|op| op.to_cbor_value())
-                .collect::<Result<Vec<_>, _>>()?;
-            map.push((KEY_OPS.to_cbor_value()?, Value::Array(arr)));
+            map.push((KEY_OPS.to_cbor_value()?, to_cbor_array(self.key_ops)?));
         }
         if !self.base_iv.is_empty() {
             map.push((BASE_IV.to_cbor_value()?, Value::Bytes(self.base_iv)));

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -52,7 +52,7 @@ impl AsCborValue for CoseKeySet {
             value
                 .try_as_array()?
                 .into_iter()
-                .map(|v| CoseKey::from_cbor_value(v))
+                .map(CoseKey::from_cbor_value)
                 .collect::<Result<Vec<_>, _>>()?,
         ))
     }

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     cbor::value::Value,
     iana,
     util::{cbor_type_error, to_cbor_array, AsCborValue, ValueTryAs},
-    CoseError, CoseRecipient, Header, ProtectedHeader,
+    CoseError, CoseRecipient, Header, ProtectedHeader, Result,
 };
 use alloc::{borrow::ToOwned, vec, vec::Vec};
 
@@ -54,7 +54,7 @@ impl crate::TaggedCborSerializable for CoseMac {
 }
 
 impl AsCborValue for CoseMac {
-    fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
+    fn from_cbor_value(value: Value) -> Result<Self> {
         let mut a = value.try_as_array()?;
         if a.len() != 5 {
             return Err(CoseError::UnexpectedType("array", "array with 5 items"));
@@ -81,7 +81,7 @@ impl AsCborValue for CoseMac {
         })
     }
 
-    fn to_cbor_value(self) -> Result<Value, CoseError> {
+    fn to_cbor_value(self) -> Result<Value> {
         Ok(Value::Array(vec![
             self.protected.cbor_bstr()?,
             self.unprotected.to_cbor_value()?,
@@ -199,7 +199,7 @@ impl crate::TaggedCborSerializable for CoseMac0 {
 }
 
 impl AsCborValue for CoseMac0 {
-    fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
+    fn from_cbor_value(value: Value) -> Result<Self> {
         let mut a = value.try_as_array()?;
         if a.len() != 4 {
             return Err(CoseError::UnexpectedType("array", "array with 4 items"));
@@ -218,7 +218,7 @@ impl AsCborValue for CoseMac0 {
         })
     }
 
-    fn to_cbor_value(self) -> Result<Value, CoseError> {
+    fn to_cbor_value(self) -> Result<Value> {
         Ok(Value::Array(vec![
             self.protected.cbor_bstr()?,
             self.unprotected.to_cbor_value()?,

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     cbor,
     cbor::value::Value,
     iana,
-    util::{cbor_type_error, AsCborValue, ValueTryAs},
+    util::{cbor_type_error, to_cbor_array, AsCborValue, ValueTryAs},
     CoseError, CoseRecipient, Header, ProtectedHeader,
 };
 use alloc::{borrow::ToOwned, vec, vec::Vec};
@@ -90,12 +90,7 @@ impl AsCborValue for CoseMac {
                 Some(b) => Value::Bytes(b),
             },
             Value::Bytes(self.tag),
-            Value::Array(
-                self.recipients
-                    .into_iter()
-                    .map(|r| r.to_cbor_value())
-                    .collect::<Result<Vec<_>, _>>()?,
-            ),
+            to_cbor_array(self.recipients)?,
         ]))
     }
 }

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -65,7 +65,7 @@ impl AsCborValue for CoseMac {
             .remove(4)
             .try_as_array()?
             .into_iter()
-            .map(|val| CoseRecipient::from_cbor_value(val))
+            .map(CoseRecipient::from_cbor_value)
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     cbor,
     cbor::value::Value,
     iana,
-    util::{cbor_type_error, AsCborValue},
+    util::{cbor_type_error, AsCborValue, ValueTryAs},
     CoseError, CoseRecipient, Header, ProtectedHeader,
 };
 use alloc::{borrow::ToOwned, vec, vec::Vec};
@@ -55,30 +55,19 @@ impl crate::TaggedCborSerializable for CoseMac {
 
 impl AsCborValue for CoseMac {
     fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
-        let mut a = match value {
-            Value::Array(a) => a,
-            v => return cbor_type_error(&v, "array"),
-        };
+        let mut a = value.try_as_array()?;
         if a.len() != 5 {
             return Err(CoseError::UnexpectedType("array", "array with 5 items"));
         }
 
         // Remove array elements in reverse order to avoid shifts.
         let mut recipients = Vec::new();
-        match a.remove(4) {
-            Value::Array(a) => {
-                for val in a {
-                    recipients.push(CoseRecipient::from_cbor_value(val)?);
-                }
-            }
-            v => return cbor_type_error(&v, "array"),
+        for val in a.remove(4).try_as_array()? {
+            recipients.push(CoseRecipient::from_cbor_value(val)?);
         }
         Ok(Self {
             recipients,
-            tag: match a.remove(3) {
-                Value::Bytes(b) => b,
-                v => return cbor_type_error(&v, "bstr"),
-            },
+            tag: a.remove(3).try_as_bytes()?,
             payload: match a.remove(2) {
                 Value::Bytes(b) => Some(b),
                 Value::Null => None,
@@ -213,20 +202,14 @@ impl crate::TaggedCborSerializable for CoseMac0 {
 
 impl AsCborValue for CoseMac0 {
     fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
-        let mut a = match value {
-            Value::Array(a) => a,
-            v => return cbor_type_error(&v, "array"),
-        };
+        let mut a = value.try_as_array()?;
         if a.len() != 4 {
             return Err(CoseError::UnexpectedType("array", "array with 4 items"));
         }
 
         // Remove array elements in reverse order to avoid shifts.
         Ok(Self {
-            tag: match a.remove(3) {
-                Value::Bytes(b) => b,
-                v => return cbor_type_error(&v, "bstr"),
-            },
+            tag: a.remove(3).try_as_bytes()?,
             payload: match a.remove(2) {
                 Value::Bytes(b) => Some(b),
                 Value::Null => None,

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -63,10 +63,7 @@ impl AsCborValue for CoseMac {
         // Remove array elements in reverse order to avoid shifts.
         let recipients = a
             .remove(4)
-            .try_as_array()?
-            .into_iter()
-            .map(CoseRecipient::from_cbor_value)
-            .collect::<Result<Vec<_>, _>>()?;
+            .try_as_array_then_convert(CoseRecipient::from_cbor_value)?;
 
         Ok(Self {
             recipients,

--- a/src/sign/mod.rs
+++ b/src/sign/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     cbor::value::Value,
     iana,
     util::{cbor_type_error, to_cbor_array, AsCborValue, ValueTryAs},
-    CoseError, Header, ProtectedHeader,
+    CoseError, Header, ProtectedHeader, Result,
 };
 use alloc::{borrow::ToOwned, vec, vec::Vec};
 
@@ -46,7 +46,7 @@ pub struct CoseSignature {
 impl crate::CborSerializable for CoseSignature {}
 
 impl AsCborValue for CoseSignature {
-    fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
+    fn from_cbor_value(value: Value) -> Result<Self> {
         let mut a = value.try_as_array()?;
         if a.len() != 3 {
             return Err(CoseError::UnexpectedType("array", "array with 3 items"));
@@ -60,7 +60,7 @@ impl AsCborValue for CoseSignature {
         })
     }
 
-    fn to_cbor_value(self) -> Result<Value, CoseError> {
+    fn to_cbor_value(self) -> Result<Value> {
         Ok(Value::Array(vec![
             self.protected.cbor_bstr()?,
             self.unprotected.to_cbor_value()?,
@@ -103,7 +103,7 @@ impl crate::TaggedCborSerializable for CoseSign {
 }
 
 impl AsCborValue for CoseSign {
-    fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
+    fn from_cbor_value(value: Value) -> Result<Self> {
         let mut a = value.try_as_array()?;
         if a.len() != 4 {
             return Err(CoseError::UnexpectedType("array", "array with 4 items"));
@@ -130,7 +130,7 @@ impl AsCborValue for CoseSign {
         })
     }
 
-    fn to_cbor_value(self) -> Result<Value, CoseError> {
+    fn to_cbor_value(self) -> Result<Value> {
         Ok(Value::Array(vec![
             self.protected.cbor_bstr()?,
             self.unprotected.to_cbor_value()?,
@@ -242,7 +242,7 @@ impl crate::TaggedCborSerializable for CoseSign1 {
 }
 
 impl AsCborValue for CoseSign1 {
-    fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
+    fn from_cbor_value(value: Value) -> Result<Self> {
         let mut a = value.try_as_array()?;
         if a.len() != 4 {
             return Err(CoseError::UnexpectedType("array", "array with 4 items"));
@@ -261,7 +261,7 @@ impl AsCborValue for CoseSign1 {
         })
     }
 
-    fn to_cbor_value(self) -> Result<Value, CoseError> {
+    fn to_cbor_value(self) -> Result<Value> {
         Ok(Value::Array(vec![
             self.protected.cbor_bstr()?,
             self.unprotected.to_cbor_value()?,

--- a/src/sign/mod.rs
+++ b/src/sign/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     cbor,
     cbor::value::Value,
     iana,
-    util::{cbor_type_error, AsCborValue},
+    util::{cbor_type_error, AsCborValue, ValueTryAs},
     CoseError, Header, ProtectedHeader,
 };
 use alloc::{borrow::ToOwned, vec, vec::Vec};
@@ -47,20 +47,14 @@ impl crate::CborSerializable for CoseSignature {}
 
 impl AsCborValue for CoseSignature {
     fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
-        let mut a = match value {
-            Value::Array(a) => a,
-            v => return cbor_type_error(&v, "array"),
-        };
+        let mut a = value.try_as_array()?;
         if a.len() != 3 {
             return Err(CoseError::UnexpectedType("array", "array with 3 items"));
         }
 
         // Remove array elements in reverse order to avoid shifts.
         Ok(Self {
-            signature: match a.remove(2) {
-                Value::Bytes(b) => b,
-                v => return cbor_type_error(&v, "bstr"),
-            },
+            signature: a.remove(2).try_as_bytes()?,
             unprotected: Header::from_cbor_value(a.remove(1))?,
             protected: ProtectedHeader::from_cbor_bstr(a.remove(0))?,
         })
@@ -110,34 +104,24 @@ impl crate::TaggedCborSerializable for CoseSign {
 
 impl AsCborValue for CoseSign {
     fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
-        let mut a = match value {
-            Value::Array(a) => a,
-            v => return cbor_type_error(&v, "array"),
-        };
+        let mut a = value.try_as_array()?;
         if a.len() != 4 {
             return Err(CoseError::UnexpectedType("array", "array with 4 items"));
         }
 
         // Remove array elements in reverse order to avoid shifts.
         let mut signatures = vec![];
-        match a.remove(3) {
-            Value::Array(sigs) => {
-                for sig in sigs.into_iter() {
-                    match CoseSignature::from_cbor_value(sig) {
-                        Ok(s) => signatures.push(s),
-                        Err(_e) => {
-                            return Err(CoseError::UnexpectedType(
-                                "non-signature",
-                                "map for COSE_Signature",
-                            ));
-                        }
-                    }
+        for sig in a.remove(3).try_as_array()?.into_iter() {
+            match CoseSignature::from_cbor_value(sig) {
+                Ok(s) => signatures.push(s),
+                Err(_e) => {
+                    return Err(CoseError::UnexpectedType(
+                        "non-signature",
+                        "map for COSE_Signature",
+                    ));
                 }
             }
-            v => {
-                return cbor_type_error(&v, "array of COSE_Signature");
-            }
-        };
+        }
 
         Ok(Self {
             signatures,
@@ -269,20 +253,14 @@ impl crate::TaggedCborSerializable for CoseSign1 {
 
 impl AsCborValue for CoseSign1 {
     fn from_cbor_value(value: Value) -> Result<Self, CoseError> {
-        let mut a = match value {
-            Value::Array(a) => a,
-            v => return cbor_type_error(&v, "array"),
-        };
+        let mut a = value.try_as_array()?;
         if a.len() != 4 {
             return Err(CoseError::UnexpectedType("array", "array with 4 items"));
         }
 
         // Remove array elements in reverse order to avoid shifts.
         Ok(Self {
-            signature: match a.remove(3) {
-                Value::Bytes(b) => b,
-                v => return cbor_type_error(&v, "bstr"),
-            },
+            signature: a.remove(3).try_as_bytes()?,
             payload: match a.remove(2) {
                 Value::Bytes(b) => Some(b),
                 Value::Null => None,

--- a/src/sign/mod.rs
+++ b/src/sign/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     cbor,
     cbor::value::Value,
     iana,
-    util::{cbor_type_error, AsCborValue, ValueTryAs},
+    util::{cbor_type_error, to_cbor_array, AsCborValue, ValueTryAs},
     CoseError, Header, ProtectedHeader,
 };
 use alloc::{borrow::ToOwned, vec, vec::Vec};
@@ -138,12 +138,7 @@ impl AsCborValue for CoseSign {
                 Some(b) => Value::Bytes(b),
                 None => Value::Null,
             },
-            Value::Array(
-                self.signatures
-                    .into_iter()
-                    .map(|sig| sig.to_cbor_value())
-                    .collect::<Result<Vec<_>, _>>()?,
-            ),
+            to_cbor_array(self.signatures)?,
         ]))
     }
 }

--- a/src/sign/mod.rs
+++ b/src/sign/mod.rs
@@ -114,7 +114,7 @@ impl AsCborValue for CoseSign {
             .remove(3)
             .try_as_array()?
             .into_iter()
-            .map(|sig| CoseSignature::from_cbor_value(sig))
+            .map(CoseSignature::from_cbor_value)
             .collect::<Result<Vec<_>, _>>()
             .map_err(|_e| CoseError::UnexpectedType("non-signature", "map for COSE_Signature"))?;
 

--- a/src/sign/mod.rs
+++ b/src/sign/mod.rs
@@ -110,13 +110,10 @@ impl AsCborValue for CoseSign {
         }
 
         // Remove array elements in reverse order to avoid shifts.
-        let signatures = a
-            .remove(3)
-            .try_as_array()?
-            .into_iter()
-            .map(CoseSignature::from_cbor_value)
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|_e| CoseError::UnexpectedType("non-signature", "map for COSE_Signature"))?;
+        let signatures = a.remove(3).try_as_array_then_convert(|v| {
+            CoseSignature::from_cbor_value(v)
+                .map_err(|_e| CoseError::UnexpectedType("non-signature", "map for COSE_Signature"))
+        })?;
 
         Ok(Self {
             signatures,

--- a/src/sign/tests.rs
+++ b/src/sign/tests.rs
@@ -152,7 +152,7 @@ fn test_cose_signature_decode_fail() {
                 "a0",       // 0-map
                 "43010203", // 3-bstr
             ),
-            "expected bstr encoded map",
+            "expected bstr",
         ),
         (
             concat!(
@@ -431,7 +431,7 @@ fn test_cose_sign_decode_fail() {
                 "43010203", // 3-bstr
                 "80",       // 0-tuple
             ),
-            "expected bstr encoded map",
+            "expected bstr",
         ),
         (
             concat!(
@@ -461,7 +461,7 @@ fn test_cose_sign_decode_fail() {
                 "43010203", // 3-bstr
                 "43010203", // 3-bstr
             ),
-            "expected array of COSE_Signature",
+            "expected array",
         ),
         (
             concat!(
@@ -530,7 +530,7 @@ fn test_cose_sign_tagged_decode_fail() {
                 "43010203", // 3-bstr
                 "80",       // 0-tuple
             ),
-            "expected bstr encoded map",
+            "expected bstr",
         ),
         (
             concat!(
@@ -872,7 +872,7 @@ fn test_cose_sign1_decode_fail() {
                 "43010203", // 3-bstr
                 "40",       // 0-bstr
             ),
-            "expected bstr encoded map",
+            "expected bstr",
         ),
         (
             concat!(
@@ -999,7 +999,7 @@ fn test_cose_sign1_tagged_decode_fail() {
                 "43010203", // 3-bstr
                 "40",       // 0-bstr
             ),
-            "expected bstr encoded map",
+            "expected bstr",
         ),
         (
             concat!(

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -116,6 +116,20 @@ pub trait AsCborValue: Sized {
     fn to_cbor_value(self) -> Result<Value, CoseError>;
 }
 
+/// Convert each item to CBOR, and wrap the lot in
+/// a Value::Array
+pub fn to_cbor_array<C>(c: C) -> Result<Value, CoseError>
+where
+    C: IntoIterator,
+    C::Item: AsCborValue,
+{
+    Ok(Value::Array(
+        c.into_iter()
+            .map(|e| e.to_cbor_value())
+            .collect::<Result<Vec<_>, _>>()?,
+    ))
+}
+
 /// Check for an expected error.
 #[cfg(test)]
 pub fn expect_err<T: core::fmt::Debug, E: core::fmt::Debug>(result: Result<T, E>, err_msg: &str) {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -53,6 +53,10 @@ where
 
     fn try_as_array(self) -> Result<Vec<Self>>;
 
+    fn try_as_array_then_convert<F, T>(self, f: F) -> Result<Vec<T>>
+    where
+        F: Fn(Value) -> Result<T>;
+
     fn try_as_map(self) -> Result<Vec<(Self, Self)>>;
 
     fn try_as_tag(self) -> Result<(u64, Box<Value>)>;
@@ -89,6 +93,16 @@ impl ValueTryAs for Value {
         } else {
             cbor_type_error(&self, "array")
         }
+    }
+
+    fn try_as_array_then_convert<F, T>(self, f: F) -> Result<Vec<T>>
+    where
+        F: Fn(Value) -> Result<T>,
+    {
+        self.try_as_array()?
+            .into_iter()
+            .map(f)
+            .collect::<Result<Vec<_>, _>>()
     }
 
     fn try_as_map(self) -> Result<Vec<(Self, Self)>> {


### PR DESCRIPTION
- Add a crate-specific `Result` type
- Match on Labels in match statements
- Add `ValueTryAs` trait to quickly extract expected types
- `to_cbor_array` for very common conversion