### PR TITLE
Convenience routines for Vec conversion

### DIFF
--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     cbor::value::Value,
     iana,
     iana::EnumI64,
-    util::{cbor_type_error, AsCborValue, ValueTryAs},
+    util::{cbor_type_error, to_cbor_array, AsCborValue, ValueTryAs},
     Algorithm, CborSerializable, CoseError, CoseSignature, Label, RegisteredLabel, Result,
 };
 use alloc::{collections::BTreeSet, string::String, vec, vec::Vec};
@@ -211,11 +211,7 @@ impl AsCborValue for Header {
             map.push((ALG.to_cbor_value()?, alg.to_cbor_value()?));
         }
         if !self.crit.is_empty() {
-            let mut arr = Vec::new();
-            for c in self.crit {
-                arr.push(c.to_cbor_value()?);
-            }
-            map.push((CRIT.to_cbor_value()?, Value::Array(arr)));
+            map.push((CRIT.to_cbor_value()?, to_cbor_array(self.crit)?));
         }
         if let Some(content_type) = self.content_type {
             map.push((CONTENT_TYPE.to_cbor_value()?, content_type.to_cbor_value()?));
@@ -237,11 +233,10 @@ impl AsCborValue for Header {
                     self.counter_signatures.remove(0).to_cbor_value()?,
                 ));
             } else {
-                let mut arr = Vec::new();
-                for cs in self.counter_signatures {
-                    arr.push(cs.to_cbor_value()?);
-                }
-                map.push((COUNTER_SIG.to_cbor_value()?, Value::Array(arr)));
+                map.push((
+                    COUNTER_SIG.to_cbor_value()?,
+                    to_cbor_array(self.counter_signatures)?,
+                ));
             }
         }
         let mut seen = BTreeSet::new();

--- a/src/sign/mod.rs
+++ b/src/sign/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     cbor,
     cbor::value::Value,
     iana,
-    util::{cbor_type_error, AsCborValue, ValueTryAs},
+    util::{cbor_type_error, to_cbor_array, AsCborValue, ValueTryAs},
     CoseError, Header, ProtectedHeader, Result,
 };
 use alloc::{borrow::ToOwned, vec, vec::Vec};
@@ -110,18 +110,10 @@ impl AsCborValue for CoseSign {
         }
 
         // Remove array elements in reverse order to avoid shifts.
-        let mut signatures = vec![];
-        for sig in a.remove(3).try_as_array()?.into_iter() {
-            match CoseSignature::from_cbor_value(sig) {
-                Ok(s) => signatures.push(s),
-                Err(_e) => {
-                    return Err(CoseError::UnexpectedItem(
-                        "non-signature",
-                        "map for COSE_Signature",
-                    ));
-                }
-            }
-        }
+        let signatures = a.remove(3).try_as_array_then_convert(|v| {
+            CoseSignature::from_cbor_value(v)
+                .map_err(|_e| CoseError::UnexpectedItem("non-signature", "map for COSE_Signature"))
+        })?;
 
         Ok(Self {
             signatures,
@@ -136,20 +128,15 @@ impl AsCborValue for CoseSign {
     }
 
     fn to_cbor_value(self) -> Result<Value> {
-        let mut v = vec![
+        Ok(Value::Array(vec![
             self.protected.cbor_bstr()?,
             self.unprotected.to_cbor_value()?,
             match self.payload {
                 Some(b) => Value::Bytes(b),
                 None => Value::Null,
             },
-        ];
-        let mut arr = Vec::new();
-        for sig in self.signatures {
-            arr.push(sig.to_cbor_value()?);
-        }
-        v.push(Value::Array(arr));
-        Ok(Value::Array(v))
+            to_cbor_array(self.signatures)?,
+        ]))
     }
 }
 


### PR DESCRIPTION
Add to_cbor_array and try_as_array_then_convert for converting vectors between CBOR and internal representations.