### PR TITLE
Directly activate alloc feature of ciborium-io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.1 - TBD
 
 - Implement `Display` for `CoseError`.
+- Fix `Cargo.toml` to indicate reliance on `alloc` feature of `ciborium-io`.
 
 ## 0.3.0 - 2022-01-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "coset"
-version = "0.3.0"
+version = "0.3.1-alpha.1"
 dependencies = [
  "ciborium",
  "ciborium-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coset"
-version = "0.3.0"
+version = "0.3.1-alpha.1"
 authors = ["David Drysdale <drysdale@google.com>", "Paul Crowley <paulcrowley@google.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ categories = ["cryptography"]
 
 [dependencies]
 ciborium = { version = "^0.2.0", default-features = false }
-ciborium-io = "^0.2.0"
+ciborium-io = { version = "^0.2.0", features = ["alloc"] }
 
 [dev-dependencies]
 hex = "^0.4.2"


### PR DESCRIPTION
The code relies on the `alloc` feature of the `ciborium-io` crate, but
does not activate it directly. Instead, the feature gets activate by
the dependence on `ciborium`, which does explictly rely on the `alloc`
feature.

The additive nature of features in Cargo means that the `alloc` feature
is therefore always enabled, but it's better to be clear/explicit about
what is needed from dependencies.