### PR TITLE
Make `AsCborValue` trait public

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     cbor::value::Value,
     iana,
     iana::{EnumI64, WithPrivateRange},
-    util::{cbor_type_error, AsCborValue, ValueTryAs},
+    util::{cbor_type_error, ValueTryAs},
 };
 use alloc::{boxed::Box, string::String, vec::Vec};
 use core::{cmp::Ordering, convert::TryInto};
@@ -142,6 +142,14 @@ fn read_to_value(slice: &[u8]) -> Result<Value> {
     } else {
         Err(CoseError::ExtraneousData)
     }
+}
+
+/// Trait for types that can be converted to/from a [`Value`].
+pub trait AsCborValue: Sized {
+    /// Convert a [`Value`] into an instance of the type.
+    fn from_cbor_value(value: Value) -> Result<Self>;
+    /// Convert the object into a [`Value`], consuming it along the way.
+    fn to_cbor_value(self) -> Result<Value>;
 }
 
 /// Extension trait that adds serialization/deserialization methods.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -18,8 +18,9 @@
 
 use crate::{
     cbor::value::Value,
+    common::AsCborValue,
     iana,
-    util::{cbor_type_error, AsCborValue, ValueTryAs},
+    util::{cbor_type_error, ValueTryAs},
     Algorithm, CoseError, ProtectedHeader, Result,
 };
 use alloc::{vec, vec::Vec};

--- a/src/encrypt/mod.rs
+++ b/src/encrypt/mod.rs
@@ -19,8 +19,9 @@
 use crate::{
     cbor,
     cbor::value::Value,
+    common::AsCborValue,
     iana,
-    util::{cbor_type_error, to_cbor_array, AsCborValue, ValueTryAs},
+    util::{cbor_type_error, to_cbor_array, ValueTryAs},
     CoseError, Header, ProtectedHeader, Result,
 };
 use alloc::{borrow::ToOwned, vec, vec::Vec};

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -18,9 +18,10 @@
 
 use crate::{
     cbor::value::Value,
+    common::AsCborValue,
     iana,
     iana::EnumI64,
-    util::{cbor_type_error, to_cbor_array, AsCborValue, ValueTryAs},
+    util::{cbor_type_error, to_cbor_array, ValueTryAs},
     Algorithm, CborSerializable, CoseError, CoseSignature, Label, RegisteredLabel, Result,
 };
 use alloc::{collections::BTreeSet, string::String, vec, vec::Vec};

--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -18,9 +18,10 @@
 
 use crate::{
     cbor::value::Value,
+    common::AsCborValue,
     iana,
     iana::EnumI64,
-    util::{to_cbor_array, AsCborValue, ValueTryAs},
+    util::{to_cbor_array, ValueTryAs},
     Algorithm, CoseError, Label, Result,
 };
 use alloc::{collections::BTreeSet, vec, vec::Vec};

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -19,8 +19,9 @@
 use crate::{
     cbor,
     cbor::value::Value,
+    common::AsCborValue,
     iana,
-    util::{cbor_type_error, to_cbor_array, AsCborValue, ValueTryAs},
+    util::{cbor_type_error, to_cbor_array, ValueTryAs},
     CoseError, CoseRecipient, Header, ProtectedHeader, Result,
 };
 use alloc::{borrow::ToOwned, vec, vec::Vec};

--- a/src/sign/mod.rs
+++ b/src/sign/mod.rs
@@ -19,8 +19,9 @@
 use crate::{
     cbor,
     cbor::value::Value,
+    common::AsCborValue,
     iana,
-    util::{cbor_type_error, to_cbor_array, AsCborValue, ValueTryAs},
+    util::{cbor_type_error, to_cbor_array, ValueTryAs},
     CoseError, Header, ProtectedHeader, Result,
 };
 use alloc::{borrow::ToOwned, vec, vec::Vec};

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -18,6 +18,7 @@
 
 use crate::{
     cbor::value::{Integer, Value},
+    common::AsCborValue,
     CoseError, Result,
 };
 use alloc::{boxed::Box, vec::Vec};
@@ -130,14 +131,6 @@ impl ValueTryAs for Value {
             cbor_type_error(&self, "tag")
         }
     }
-}
-
-/// Trait for types that can be converted to/from a [`Value`].
-pub trait AsCborValue: Sized {
-    /// Convert a [`Value`] into an instance of the type.
-    fn from_cbor_value(value: Value) -> Result<Self>;
-    /// Convert the object into a [`Value`], consuming it along the way.
-    fn to_cbor_value(self) -> Result<Value>;
 }
 
 /// Convert each item of an iterator to CBOR, and wrap the lot in


### PR DESCRIPTION
## Summary
This pull request makes the `AsCborValue` trait public, moving it from `util` to `common` and allowing clients of this library to call `from_cbor_value` and `to_cbor_value` for the COSE objects.

## Reasoning
This is helpful in cases where users want to embed COSE objects into other CBOR structures. 
For example, proof-of-possession keys as described in [RFC 8747, section 3](https://www.rfc-editor.org/rfc/rfc8747.html#section-3) are represented by embedding a `COSE_Key` or `COSE_Encrypt` structure into a CBOR map. Representing this structure from RFC 8747 as a struct in Rust and then serializing it into CBOR using `ciborium` becomes significantly easier once `coset` objects can be turned into `Value`s. AFAICT, COSE objects in `coset` can currently only be directly serialized into `Vec<u8>` — serializing into a ciborium `Value` requires the `AsCborValue` trait to be public. The same reasoning applies to deserialization.