### PR TITLE
ci: pin cargo-tarpaulin 0.20.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,7 @@ jobs:
       - uses: actions-rs/install@69ec87709ffb5b19a7b5ddbf610cb221498bb1eb # v0.1.2
         with:
           crate: cargo-tarpaulin
+          version: 0.20.1
           use-tool-cache: true
       - run: cargo tarpaulin --verbose --ignore-tests --all-features --timeout=600 --out Xml
       - name: Upload to codecov.io


### PR DESCRIPTION
Temporary pin while version 0.21.0 fails to build in CI.