### PR TITLE
Remove MeasuringReader.

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -107,40 +107,22 @@ impl CoseError {
     }
 }
 
-/// Newtype wrapper around a byte slice to allow left-over data to be detected.
-struct MeasuringReader<'a>(&'a [u8]);
-
-impl<'a> MeasuringReader<'a> {
-    fn new(buf: &'a [u8]) -> MeasuringReader<'a> {
-        MeasuringReader(buf)
-    }
-
-    fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
-impl<'a> ciborium_io::Read for &mut MeasuringReader<'a> {
-    type Error = EndOfFile;
-
-    fn read_exact(&mut self, data: &mut [u8]) -> Result<(), Self::Error> {
-        if data.len() > self.0.len() {
-            return Err(EndOfFile);
-        }
-
-        let (prefix, suffix) = self.0.split_at(data.len());
-        data.copy_from_slice(prefix);
-        self.0 = suffix;
-        Ok(())
+/// Convert a Ciborium error to one that uses our EndOfFile marker.
+fn convert_cbor_err<T>(e: cbor::de::Error<T>) -> cbor::de::Error<EndOfFile> {
+    use cbor::de::Error::{Io, RecursionLimitExceeded, Semantic, Syntax};
+    match e {
+        Io(_) => Io(EndOfFile),
+        Syntax(x) => Syntax(x),
+        Semantic(a, b) => Semantic(a, b),
+        RecursionLimitExceeded => RecursionLimitExceeded,
     }
 }
 
 /// Read a CBOR [`Value`] from a byte slice, failing if any extra data remains after the `Value` has
 /// been read.
-fn read_to_value(slice: &[u8]) -> Result<Value> {
-    let mut mr = MeasuringReader::new(slice);
-    let value = cbor::de::from_reader(&mut mr)?;
-    if mr.is_empty() {
+fn read_to_value(mut slice: &[u8]) -> Result<Value> {
+    let value = cbor::de::from_reader(&mut slice).map_err(convert_cbor_err)?;
+    if slice.is_empty() {
         Ok(value)
     } else {
         Err(CoseError::ExtraneousData)


### PR DESCRIPTION
Ciborium implements Read for &mut R for any R that itself implementats Read. So we can just pass our slice by reference rather than by value when decoding, and then we can directly check whether it has been fully consumed.

That simplifies things a bit. Unfortunately we then need to do some munging of the error type, which complicates things.