### PR TITLE
common: cope with i64::MIN in PartialOrd

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -216,7 +216,7 @@ impl Ord for Label {
     fn cmp(&self, other: &Self) -> Ordering {
         match (self, other) {
             (Label::Int(i1), Label::Int(i2)) => match (i1.signum(), i2.signum()) {
-                (-1, -1) => (-i1).cmp(&(-i2)),
+                (-1, -1) => i2.cmp(i1),
                 (-1, 0) => Ordering::Greater,
                 (-1, 1) => Ordering::Greater,
                 (0, -1) => Ordering::Less,

--- a/src/common/tests.rs
+++ b/src/common/tests.rs
@@ -68,6 +68,10 @@ fn test_label_sort() {
         (Label::Int(0x1234), Label::Int(0x1235)),
         (Label::Text("a".to_owned()), Label::Text("ab".to_owned())),
         (Label::Text("aa".to_owned()), Label::Text("ab".to_owned())),
+        (Label::Int(i64::MAX - 2), Label::Int(i64::MAX - 1)),
+        (Label::Int(i64::MAX - 1), Label::Int(i64::MAX)),
+        (Label::Int(i64::MIN + 2), Label::Int(i64::MIN + 1)),
+        (Label::Int(i64::MIN + 1), Label::Int(i64::MIN)),
     ];
     for (left, right) in pairs.into_iter() {
         let value_cmp = left.cmp(&right);


### PR DESCRIPTION
Negating i64::MIN gives a positive value that is > i64::MAX.