### PR TITLE
sign: make to-be-signed function publicly for async signing

### DIFF
--- a/src/sign/mod.rs
+++ b/src/sign/mod.rs
@@ -181,7 +181,7 @@ impl CoseSign {
     }
 
     /// Construct the to-be-signed data for this object.
-    fn tbs_data(&self, aad: &[u8], sig: &CoseSignature) -> Vec<u8> {
+    pub fn tbs_data(&self, aad: &[u8], sig: &CoseSignature) -> Vec<u8> {
         sig_structure_data(
             SignatureContext::CoseSignature,
             self.protected.clone(),
@@ -196,7 +196,7 @@ impl CoseSign {
     /// # Panics
     ///
     /// This method will panic if `self.payload.is_some()`.
-    fn tbs_detached_data(&self, payload: &[u8], aad: &[u8], sig: &CoseSignature) -> Vec<u8> {
+    pub fn tbs_detached_data(&self, payload: &[u8], aad: &[u8], sig: &CoseSignature) -> Vec<u8> {
         assert!(self.payload.is_none());
         sig_structure_data(
             SignatureContext::CoseSignature,
@@ -387,7 +387,7 @@ impl CoseSign1 {
     }
 
     /// Construct the to-be-signed data for this object.
-    fn tbs_data(&self, aad: &[u8]) -> Vec<u8> {
+    pub fn tbs_data(&self, aad: &[u8]) -> Vec<u8> {
         sig_structure_data(
             SignatureContext::CoseSign1,
             self.protected.clone(),
@@ -402,7 +402,7 @@ impl CoseSign1 {
     /// # Panics
     ///
     /// This method will panic if `self.payload.is_some()`.
-    fn tbs_detached_data(&self, payload: &[u8], aad: &[u8]) -> Vec<u8> {
+    pub fn tbs_detached_data(&self, payload: &[u8], aad: &[u8]) -> Vec<u8> {
         assert!(self.payload.is_none());
         sig_structure_data(
             SignatureContext::CoseSign1,


### PR DESCRIPTION
In our usage scenarios, two factors require the use of the tbs_data function:
1. Signatures are generated by a trusted remote service and the local service does not hold the private key.
2. The local service may need to use multiple public keys to attempt to verify the signatures. 