### PR TITLE
header: fix authentication when protected header is zero-length map

### DIFF
--- a/src/encrypt/mod.rs
+++ b/src/encrypt/mod.rs
@@ -496,7 +496,7 @@ pub fn enc_structure_data(
 ) -> Vec<u8> {
     let arr = vec![
         Value::Text(context.text().to_owned()),
-        protected.cbor_bstr().expect("failed to serialize header"), // safe: always serializable
+        protected.to_be_authenticated().expect("failed to serialize header"), // safe: always serializable
         Value::Bytes(external_aad.to_vec()),
     ];
 

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -385,6 +385,19 @@ impl ProtectedHeader {
         ))
     }
 
+    pub fn to_be_authenticated(self) -> Result<Value> {
+        let result = self.cbor_bstr()?;
+        // protected header might have been encoded as a zero length map, only containing
+        // the byte 0xA0 (see RFC 9052, Section 3).
+        // However, this byte should not be included during authentication (RFC 9052, Section 4.4,
+        // 5.3 and 6.3), so we need to return an empty byte string here instead.
+        if result.eq(&Value::Bytes(vec![0xA0])) {
+            Ok(Value::Bytes(vec![]))
+        } else {
+            Ok(result)
+        }
+    }
+
     /// Indicate whether the `ProtectedHeader` is empty.
     pub fn is_empty(&self) -> bool {
         self.header.is_empty()

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -336,7 +336,7 @@ pub fn mac_structure_data(
 ) -> Vec<u8> {
     let arr = vec![
         Value::Text(context.text().to_owned()),
-        protected.cbor_bstr().expect("failed to serialize header"), // safe: always serializable
+        protected.to_be_authenticated().expect("failed to serialize header"), // safe: always serializable
         Value::Bytes(external_aad.to_vec()),
         Value::Bytes(payload.to_vec()),
     ];

--- a/src/sign/mod.rs
+++ b/src/sign/mod.rs
@@ -518,13 +518,16 @@ pub fn sig_structure_data(
     aad: &[u8],
     payload: &[u8],
 ) -> Vec<u8> {
+
     let mut arr = vec![
         Value::Text(context.text().to_owned()),
-        body.cbor_bstr().expect("failed to serialize header"), // safe: always serializable
+        body.to_be_authenticated().expect("failed to serialize header"), // safe: always serializable
     ];
     if let Some(sign) = sign {
-        arr.push(sign.cbor_bstr().expect("failed to serialize header")); // safe: always
-                                                                         // serializable
+        arr.push(
+            sign.to_be_authenticated()
+                .expect("failed to serialize header")  // safe: always serializable
+        );
     }
     arr.push(Value::Bytes(aad.to_vec()));
     arr.push(Value::Bytes(payload.to_vec()));


### PR DESCRIPTION
COSE allows an empty protected header to be encoded as a zero-length map, even though the standard encourages encoding empty protected headers as a zero-length string (RFC 2119 SHOULD according to RFC 9052, Section 3).

However, according to RFC 9052, Section 4.4, 5.3 and 6.3, even if the header is encoded as a zero-length map, the structure used for authentication should not include the empty map if the protected header is empty ("if there are no protected attributes, a zero-length byte string is used").

Due to this, authentication of some of the official examples in the [cose-wg/Examples repository](https://github.com/cose-wg/Examples) was not possible using coset.
An example of this is the CoseSign1 object provided in
[sign1-tests/sign-pass-03.json](https://github.com/cose-wg/Examples/blob/master/sign1-tests/sign-pass-03.json), which uses the protected header encoding as a zero-length map.

This PR ensures that the correct behavior is implemented in coset by no longer including a zero-length map protected header during authentication.

Note: I am unsure as to how to proceed with the tests that now fail, as it seems like those explicitly expect a behavior different from the RFC.