### PR TITLE
Exclude `original_data` field from `PartialEq` comparison

### DIFF
--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -344,13 +344,19 @@ impl HeaderBuilder {
 }
 
 /// Structure representing a protected COSE header map.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default)]
 pub struct ProtectedHeader {
     /// If this structure was created by parsing serialized data, this field
     /// holds the entire contents of the original `bstr` data.
     pub original_data: Option<Vec<u8>>,
     /// Parsed header information.
     pub header: Header,
+}
+
+impl PartialEq for ProtectedHeader {
+    fn eq(&self, other: &Self) -> bool {
+        self.header.eq(&other.header)
+    }
 }
 
 impl ProtectedHeader {

--- a/src/header/tests.rs
+++ b/src/header/tests.rs
@@ -152,10 +152,7 @@ fn test_header_encode() {
         let got = header.clone().to_vec().unwrap();
         assert_eq!(*header_data, hex::encode(&got), "case {}", i);
 
-        let mut got = Header::from_slice(&got).unwrap();
-        for sig in &mut got.counter_signatures {
-            sig.protected.original_data = None;
-        }
+        let got = Header::from_slice(&got).unwrap();
         assert_eq!(*header, got);
         assert!(!got.is_empty());
 
@@ -167,19 +164,13 @@ fn test_header_encode() {
         let protected_data = protected.clone().to_vec().unwrap();
         assert_eq!(*header_data, hex::encode(&protected_data), "case {}", i);
 
-        let mut got = ProtectedHeader::from_slice(&protected_data).unwrap();
-        for sig in &mut got.header.counter_signatures {
-            sig.protected.original_data = None;
-        }
+        let got = ProtectedHeader::from_slice(&protected_data).unwrap();
         assert!(!got.is_empty());
         assert_eq!(*header, got.header);
 
         // Also try parsing as a protected header inside a `bstr`
         let prot_bstr_val = protected.cbor_bstr().unwrap();
-        let mut got = ProtectedHeader::from_cbor_bstr(prot_bstr_val).unwrap();
-        for sig in &mut got.header.counter_signatures {
-            sig.protected.original_data = None;
-        }
+        let got = ProtectedHeader::from_cbor_bstr(prot_bstr_val).unwrap();
         assert!(!got.is_empty());
         assert_eq!(*header, got.header);
         assert_eq!(


### PR DESCRIPTION
As `original_data` is not required to be set, used/initialised only in limited number of cases.
So to be still be consistent in comparison operation, I am suggesting to exclude `original_data` field from comparing implementation.
As a result it eliminates inconvenience to alway keep this field either empty or initialised to be able to properly compare two `ProtectedHeaders` instances at this moment.