### PR TITLE
ci: revert to use `cargo run` for running examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,11 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt
-      - run: cargo +${{ matrix.rust }} test --examples
-      - run: cargo +${{ matrix.rust }} test --features=std --examples
+      - run: |
+          for eg in `ls examples/*.rs | xargs basename --suffix=.rs`; do
+            cargo +${{ matrix.rust }} run --example ${eg};
+            cargo +${{ matrix.rust }} run --features=std --example ${eg};
+          done
 
   no_std:
     name: Build for a no_std target


### PR DESCRIPTION
This PR reverts changes in #53.

`cargo test --examples` only runs unit-tests (functions that marked with `#[test]`), not the `main` function.