### PR TITLE
Allow critical labels to contain private use label range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.4.0 - TBD
+
+- Breaking change:  alter type of `crit` field in `Header` to support private-use labels (in accordance with
+  [9052 §3.1](https://datatracker.ietf.org/doc/html/rfc9052#name-common-cose-header-paramete)).
+
 ## 0.3.8 - 2024-07-24
 
 - Make `CoseSign[1]::tbs_[detached_]data` methods `pub`.

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -22,7 +22,8 @@ use crate::{
     iana,
     iana::EnumI64,
     util::{cbor_type_error, to_cbor_array, ValueTryAs},
-    Algorithm, CborSerializable, CoseError, CoseSignature, Label, RegisteredLabel, Result,
+    Algorithm, CborSerializable, CoseError, CoseSignature, Label, RegisteredLabelWithPrivate,
+    Result,
 };
 use alloc::{collections::BTreeSet, string::String, vec, vec::Vec};
 
@@ -55,7 +56,7 @@ pub struct Header {
     /// Cryptographic algorithm to use
     pub alg: Option<Algorithm>,
     /// Critical headers to be understood
-    pub crit: Vec<RegisteredLabel<iana::HeaderParameter>>,
+    pub crit: Vec<RegisteredLabelWithPrivate<iana::HeaderParameter>>,
     /// Content type of the payload
     pub content_type: Option<ContentType>,
     /// Key identifier.
@@ -121,7 +122,7 @@ impl AsCborValue for Header {
                         }
                         for v in a {
                             headers.crit.push(
-                                RegisteredLabel::<iana::HeaderParameter>::from_cbor_value(v)?,
+                                RegisteredLabelWithPrivate::<iana::HeaderParameter>::from_cbor_value(v)?,
                             );
                         }
                     }
@@ -270,13 +271,18 @@ impl HeaderBuilder {
     /// Add a critical header.
     #[must_use]
     pub fn add_critical(mut self, param: iana::HeaderParameter) -> Self {
-        self.0.crit.push(RegisteredLabel::Assigned(param));
+        self.0
+            .crit
+            .push(RegisteredLabelWithPrivate::Assigned(param));
         self
     }
 
     /// Add a critical header.
     #[must_use]
-    pub fn add_critical_label(mut self, label: RegisteredLabel<iana::HeaderParameter>) -> Self {
+    pub fn add_critical_label(
+        mut self,
+        label: RegisteredLabelWithPrivate<iana::HeaderParameter>,
+    ) -> Self {
         self.0.crit.push(label);
         self
     }

--- a/src/header/tests.rs
+++ b/src/header/tests.rs
@@ -49,7 +49,9 @@ fn test_header_encode() {
         (
             Header {
                 alg: Some(Algorithm::Assigned(iana::Algorithm::A128GCM)),
-                crit: vec![RegisteredLabel::Assigned(iana::HeaderParameter::Alg)],
+                crit: vec![RegisteredLabelWithPrivate::Assigned(
+                    iana::HeaderParameter::Alg,
+                )],
                 content_type: Some(ContentType::Assigned(iana::CoapContentFormat::CoseEncrypt0)),
                 key_id: vec![1, 2, 3],
                 iv: vec![1, 2, 3],
@@ -73,7 +75,7 @@ fn test_header_encode() {
         (
             Header {
                 alg: Some(Algorithm::Text("abc".to_owned())),
-                crit: vec![RegisteredLabel::Text("d".to_owned())],
+                crit: vec![RegisteredLabelWithPrivate::Text("d".to_owned())],
                 content_type: Some(ContentType::Text("a/b".to_owned())),
                 key_id: vec![1, 2, 3],
                 iv: vec![1, 2, 3],
@@ -103,7 +105,7 @@ fn test_header_encode() {
         (
             Header {
                 alg: Some(Algorithm::Text("abc".to_owned())),
-                crit: vec![RegisteredLabel::Text("d".to_owned())],
+                crit: vec![RegisteredLabelWithPrivate::Text("d".to_owned())],
                 content_type: Some(ContentType::Text("a/b".to_owned())),
                 key_id: vec![1, 2, 3],
                 iv: vec![1, 2, 3],
@@ -145,6 +147,17 @@ fn test_header_encode() {
             concat!(
                 "a1", // 1-map
                 "02", "820101", // crit => 2-arr [1, 1]
+            ),
+        ),
+        (
+            HeaderBuilder::new()
+                .add_critical_label(RegisteredLabelWithPrivate::PrivateUse(-65537))
+                .build(),
+            concat!(
+                "a1", // 1-map
+                "02",
+                "81",
+                "3a00010000", // crit => 1-arr [-65537]
             ),
         ),
     ];
@@ -393,7 +406,9 @@ fn test_header_encode_dup_fail() {
     let tests = vec![
         Header {
             alg: Some(Algorithm::Assigned(iana::Algorithm::A128GCM)),
-            crit: vec![RegisteredLabel::Assigned(iana::HeaderParameter::Alg)],
+            crit: vec![RegisteredLabelWithPrivate::Assigned(
+                iana::HeaderParameter::Alg,
+            )],
             content_type: Some(ContentType::Assigned(iana::CoapContentFormat::CoseEncrypt0)),
             key_id: vec![1, 2, 3],
             iv: vec![1, 2, 3],
@@ -427,7 +442,7 @@ fn test_header_builder() {
             HeaderBuilder::new()
                 .algorithm(iana::Algorithm::A128GCM)
                 .add_critical(iana::HeaderParameter::Alg)
-                .add_critical_label(RegisteredLabel::Text("abc".to_owned()))
+                .add_critical_label(RegisteredLabelWithPrivate::Text("abc".to_owned()))
                 .content_format(iana::CoapContentFormat::CoseEncrypt0)
                 .key_id(vec![1, 2, 3])
                 .partial_iv(vec![4, 5, 6]) // removed by .iv() call
@@ -438,8 +453,8 @@ fn test_header_builder() {
             Header {
                 alg: Some(Algorithm::Assigned(iana::Algorithm::A128GCM)),
                 crit: vec![
-                    RegisteredLabel::Assigned(iana::HeaderParameter::Alg),
-                    RegisteredLabel::Text("abc".to_owned()),
+                    RegisteredLabelWithPrivate::Assigned(iana::HeaderParameter::Alg),
+                    RegisteredLabelWithPrivate::Text("abc".to_owned()),
                 ],
                 content_type: Some(ContentType::Assigned(iana::CoapContentFormat::CoseEncrypt0)),
                 key_id: vec![1, 2, 3],
@@ -455,7 +470,7 @@ fn test_header_builder() {
             HeaderBuilder::new()
                 .algorithm(iana::Algorithm::A128GCM)
                 .add_critical(iana::HeaderParameter::Alg)
-                .add_critical_label(RegisteredLabel::Text("abc".to_owned()))
+                .add_critical_label(RegisteredLabelWithPrivate::Text("abc".to_owned()))
                 .content_type("type/subtype".to_owned())
                 .key_id(vec![1, 2, 3])
                 .iv(vec![1, 2, 3]) // removed by .partial_iv() call
@@ -464,12 +479,25 @@ fn test_header_builder() {
             Header {
                 alg: Some(Algorithm::Assigned(iana::Algorithm::A128GCM)),
                 crit: vec![
-                    RegisteredLabel::Assigned(iana::HeaderParameter::Alg),
-                    RegisteredLabel::Text("abc".to_owned()),
+                    RegisteredLabelWithPrivate::Assigned(iana::HeaderParameter::Alg),
+                    RegisteredLabelWithPrivate::Text("abc".to_owned()),
                 ],
                 content_type: Some(ContentType::Text("type/subtype".to_owned())),
                 key_id: vec![1, 2, 3],
                 partial_iv: vec![4, 5, 6],
+                ..Default::default()
+            },
+        ),
+        (
+            HeaderBuilder::new()
+                .algorithm(iana::Algorithm::A128GCM)
+                .add_critical_label(RegisteredLabelWithPrivate::PrivateUse(-65537))
+                .key_id(vec![1, 2, 3])
+                .build(),
+            Header {
+                alg: Some(Algorithm::Assigned(iana::Algorithm::A128GCM)),
+                crit: vec![RegisteredLabelWithPrivate::PrivateUse(-65537)],
+                key_id: vec![1, 2, 3],
                 ..Default::default()
             },
         ),

--- a/src/sign/tests.rs
+++ b/src/sign/tests.rs
@@ -17,7 +17,7 @@
 use super::*;
 use crate::{
     cbor::value::Value, iana, util::expect_err, Algorithm, CborSerializable, ContentType,
-    HeaderBuilder, RegisteredLabel, TaggedCborSerializable,
+    HeaderBuilder, RegisteredLabelWithPrivate, TaggedCborSerializable,
 };
 use alloc::{
     format,
@@ -712,7 +712,7 @@ fn test_rfc8152_cose_sign_decode() {
             CoseSignBuilder::new()
                 .protected(HeaderBuilder::new()
                            .text_value("reserved".to_owned(), Value::Bool(false))
-                           .add_critical_label(RegisteredLabel::Text("reserved".to_owned()))
+                           .add_critical_label(RegisteredLabelWithPrivate::Text("reserved".to_owned()))
                            .build())
                 .payload(b"This is the content.".to_vec())
                 .add_signature(


### PR DESCRIPTION
The IANA COSE header registry defines the private use label range (< -65536), which should be allowed to list in the critical label.