### PR TITLE
header: allow setting custom use algorithm label

### DIFF
--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -268,6 +268,13 @@ impl HeaderBuilder {
         self
     }
 
+    /// Set the algorithm.
+    #[must_use]
+    pub fn algorithm_label(mut self, label: RegisteredLabelWithPrivate<iana::Algorithm>) -> Self {
+        self.0.alg = Some(label);
+        self
+    }
+
     /// Add a critical header.
     #[must_use]
     pub fn add_critical(mut self, param: iana::HeaderParameter) -> Self {

--- a/src/header/tests.rs
+++ b/src/header/tests.rs
@@ -501,6 +501,19 @@ fn test_header_builder() {
                 ..Default::default()
             },
         ),
+        (
+            HeaderBuilder::new()
+                .algorithm_label(Algorithm::PrivateUse(-65537))
+                .add_critical_label(RegisteredLabelWithPrivate::PrivateUse(-65537))
+                .key_id(vec![1, 2, 3])
+                .build(),
+            Header {
+                alg: Some(Algorithm::PrivateUse(-65537)),
+                crit: vec![RegisteredLabelWithPrivate::PrivateUse(-65537)],
+                key_id: vec![1, 2, 3],
+                ..Default::default()
+            },
+        ),
     ];
     for (got, want) in tests {
         assert_eq!(got, want);


### PR DESCRIPTION
Add a `algorithm_label` method to the HeaderBuilder so we can set algorithm ID with PrivateUse range.