### PR TITLE
Allow unassigned values for labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.4.0 - TBD
 
+- Breaking change: add `Unassigned(i64)` variant to `RegisteredLabel<t>` and
+  `RegisteredLabelWithPrivateRange<T>`, to allow use of values that are not yet IANA-assigned.
+- Breaking change: remove `CoseError::UnregisteredIanaValue` and
+  `CoseError::UnregisteredIanaNonPrivateValue` variants.
 - Breaking change:  alter type of `crit` field in `Header` to support private-use labels (in accordance with
   [9052 §3.1](https://datatracker.ietf.org/doc/html/rfc9052#name-common-cose-header-paramete)).
 

--- a/examples/signature.rs
+++ b/examples/signature.rs
@@ -45,10 +45,11 @@ fn main() -> Result<(), CoseError> {
     let aad = b"this is additional data";
 
     // Build a `CoseSign1` object.
-    let protected = coset::HeaderBuilder::new()
+    let mut protected = coset::HeaderBuilder::new()
         .algorithm(iana::Algorithm::ES256)
         .key_id(b"11".to_vec())
         .build();
+    protected.alg = Some(coset::Algorithm::PrivateUse(-49));
     let sign1 = coset::CoseSign1Builder::new()
         .protected(protected)
         .payload(pt.to_vec())

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -196,6 +196,19 @@ fn test_context_encode() {
                 "41", "03", // 1-bstr
             ),
         ),
+        (
+            CoseKdfContext {
+                algorithm_id: Algorithm::Unassigned(8),
+                ..CoseKdfContext::default()
+            },
+            concat!(
+                "84", // 4-tuple
+                "08", // int : unassigned value
+                "83", "f6f6f6", // 3-tuple: [nil, nil, nil]
+                "83", "f6f6f6", // 3-tuple: [nil, nil, nil]
+                "82", "0040", // 2-tuple: [0, 0-bstr]
+            ),
+        ),
     ];
     for (i, (key, key_data)) in tests.iter().enumerate() {
         let got = key.clone().to_vec().unwrap();
@@ -237,16 +250,6 @@ fn test_context_decode_fail() {
                 "83", "f6f6f6", // 3-tuple: [nil, nil, nil]
             ),
             "decode CBOR failure: Io(EndOfFile",
-        ),
-        (
-            concat!(
-                "84", // 4-tuple
-                "08", // int : unassigned value
-                "83", "f6f6f6", // 3-tuple: [nil, nil, nil]
-                "83", "f6f6f6", // 3-tuple: [nil, nil, nil]
-                "82", "0040", // 2-tuple: [0, 0-bstr]
-            ),
-            "expected value in IANA or private use range",
         ),
         (
             concat!(

--- a/src/cwt/tests.rs
+++ b/src/cwt/tests.rs
@@ -108,7 +108,9 @@ fn test_cwt_encode() {
         let got = claims.clone().to_vec().unwrap();
         assert_eq!(*claims_data, hex::encode(&got), "case {i}");
 
-        let got = ClaimsSet::from_slice(&got).unwrap();
+        let got = ClaimsSet::from_slice(&got).unwrap_or_else(|e| {
+            panic!("deserialize failed on case {}, {}: {:?}", i, claims_data, e)
+        });
         assert_eq!(*claims, got);
     }
 }

--- a/src/header/tests.rs
+++ b/src/header/tests.rs
@@ -160,6 +160,26 @@ fn test_header_encode() {
                 "3a00010000", // crit => 1-arr [-65537]
             ),
         ),
+        (
+            Header {
+                content_type: Some(ContentType::Unassigned(1542)),
+                ..Default::default()
+            },
+            concat!(
+                "a1", // 1-map
+                "03", "19", "0606", // 3 (content-type) => unassigned value 1542
+            ),
+        ),
+        (
+            Header {
+                alg: Some(Algorithm::Unassigned(8)),
+                ..Default::default()
+            },
+            concat!(
+                "a1", // 1-map
+                "01", "08", // 1 (alg) => unassigned value 8
+            ),
+        ),
     ];
     for (i, (header, header_data)) in tests.iter().enumerate() {
         let got = header.clone().to_vec().unwrap();
@@ -216,13 +236,6 @@ fn test_header_decode_fail() {
         (
             concat!(
                 "a1", // 1-map
-                "01", "08", // 1 (alg) => invalid value
-            ),
-            "expected value in IANA or private use range",
-        ),
-        (
-            concat!(
-                "a1", // 1-map
                 "01", "4101", // 1 (alg) => bstr (invalid value type)
             ),
             "expected int/tstr",
@@ -254,13 +267,6 @@ fn test_header_decode_fail() {
                 "03", "81", "4101", // 3 (content-type) => [bstr] (invalid value type)
             ),
             "expected int/tstr",
-        ),
-        (
-            concat!(
-                "a1", // 1-map
-                "03", "19", "0606", // 3 (content-type) => invalid value 1542
-            ),
-            "expected recognized IANA value",
         ),
         (
             concat!(


### PR DESCRIPTION
The previous code would reject the use of numeric label values that do not correspond to an IANA `enum` and which are outside of any defined private range.

This made it hard to deal with as-yet-unassigned label values from internet drafts, which are not yet definitive.

So add an `Unassigned(i64)` variant to cover these values.  This also means that the `UnregisteredIana[NonPrivate]Value` errors can no longer be emitted.

Fixes #112