### PR TITLE
Add CoseKeyBuilder::new_akp_key method.

### DIFF
--- a/src/key/mod.rs
+++ b/src/key/mod.rs
@@ -279,6 +279,24 @@ impl CoseKeyBuilder {
         })
     }
 
+    /// Constructor for an algorithm key pair.
+    pub fn new_akp_key(pub_key: Vec<u8>, priv_key: Vec<u8>) -> Self {
+        Self(CoseKey {
+            kty: KeyType::Assigned(iana::KeyType::AKP),
+            params: vec![
+                (
+                    Label::Int(iana::AkpKeyParameter::Pub as i64),
+                    Value::Bytes(pub_key),
+                ),
+                (
+                    Label::Int(iana::AkpKeyParameter::Priv as i64),
+                    Value::Bytes(priv_key),
+                ),
+            ],
+            ..Default::default()
+        })
+    }
+
     /// Set the key type.
     #[must_use]
     pub fn key_type(mut self, key_type: iana::KeyType) -> Self {

--- a/src/key/tests.rs
+++ b/src/key/tests.rs
@@ -703,6 +703,23 @@ fn test_key_builder() {
             },
         ),
         (
+            CoseKeyBuilder::new_akp_key(vec![1, 2, 3], vec![4, 5, 6]).build(),
+            CoseKey {
+                kty: KeyType::Assigned(iana::KeyType::AKP),
+                params: vec![
+                    (
+                        Label::Int(iana::AkpKeyParameter::Pub as i64),
+                        Value::Bytes(vec![1, 2, 3]),
+                    ),
+                    (
+                        Label::Int(iana::AkpKeyParameter::Priv as i64),
+                        Value::Bytes(vec![4, 5, 6]),
+                    ),
+                ],
+                ..Default::default()
+            },
+        ),
+        (
             CoseKeyBuilder::new_okp_key().build(),
             CoseKey {
                 kty: KeyType::Assigned(iana::KeyType::OKP),


### PR DESCRIPTION
The new AKP key type and key parameters were added in [PR #81.](https://github.com/google/coset/pull/81).