### PR TITLE
Add helper for ML-DSA public key creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.4.2 - TBD
+
+- Add `CoseKeyBuilder::new_mldsa_pub_key()` helper, with associated `MlDsaVariant` enum.
+
 ## 0.4.1 - 2026-01-19
 
 - Bump MSRV to 1.81.


### PR DESCRIPTION
As specified in draft-ietf-cose-dilithium, which is a draft and so has a small chance of changing (which would necessitate a breaking change to this crate).